### PR TITLE
fix: Remove dead link to COPYING file

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,11 @@ or, to run the testsuite with MIRI:
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 
 ## Copyright
 
 Copyright (C) 2020-2022, Stalwart Labs Ltd.
-
-See [COPYING] for the license.
-
-[COPYING]: https://github.com/stalwartlabs/mail-send/blob/main/COPYING


### PR DESCRIPTION
Removed a dead link from `README.md`.
The "License" section just above should suffice.

List-style was auto-adjusted. I kept that in the PR, because it matches the rest of the file.