### PR TITLE
fix: Dead link due to typo in lib doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //!         .unwrap();
 //! ```
 //!
-//! More examples of how to build messages are available in the [`mail-builder`](https://crates.io/crates/mail-buikder) crate.
+//! More examples of how to build messages are available in the [`mail-builder`](https://crates.io/crates/mail-builder) crate.
 //! Please note that this library does not support parsing e-mail messages as this functionality is provided separately by the [`mail-parser`](https://crates.io/crates/mail-parser) crate.
 //!
 //! ## Testing


### PR DESCRIPTION
Fixed a link leading to https://crates.io/crates/mail-buikder 

![image](https://user-images.githubusercontent.com/22329650/205969790-ba7a8b73-224a-473b-a5f6-875b313fb0bc.png)
