### PR TITLE
fix: Extend buffer from bytes read while reading EHLO

### DIFF
--- a/src/smtp/ehlo.rs
+++ b/src/smtp/ehlo.rs
@@ -67,7 +67,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> SmtpClient<T> {
                 Err(err) => match err {
                     smtp_proto::Error::NeedsMoreData { .. } => {
                         if buf_concat.is_empty() {
-                            buf_concat = buf.to_vec();
+                            buf_concat = buf[..br].to_vec();
                         }
                     }
                     smtp_proto::Error::InvalidResponse { code } => {
@@ -77,7 +77,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> SmtpClient<T> {
                             }
                             Err(smtp_proto::Error::NeedsMoreData { .. }) => {
                                 if buf_concat.is_empty() {
-                                    buf_concat = buf.to_vec();
+                                    buf_concat = buf[..br].to_vec();
                                 }
                             }
                             Err(_) => return Err(crate::Error::UnparseableReply),


### PR DESCRIPTION
Fixes #12 

(You only need to read the very bottom of https://github.com/stalwartlabs/mail-send/issues/12#issuecomment-1432226194 - the rest above that is explorative debugging.)

The above linked comment explains what is fixed here: 

When a single chunk is not enough, then the here-corrected method previously dumped the entire zeroed buffer into a vector. It then appended to the end of the full 1024 bytes on the next loop iteration.

This PR fixes this behavior by **only dumping the bytes read** into the concatenation vec.