### PR TITLE
Refactor message, send_msg(), sign()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+mail-send unreleased
+================================
+- New `send_msg(&mut self, message: &Message<'x>)`
+- New `sign(&mut self, signer: &DkimSigner<_>)` method on `Message`
+
 mail-send 0.5.0
 ================================
 - Bump `mail-parser` dependency to 0.10

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,9 @@ pub enum Error {
 
     /// STARTTLS not available
     MissingStartTls,
+
+    /// Message is already signed
+    MessageDkimSigned,
 }
 
 impl std::error::Error for Error {
@@ -249,6 +252,7 @@ impl Display for Error {
             ),
             Error::Timeout => write!(f, "Connection timeout"),
             Error::MissingStartTls => write!(f, "STARTTLS extension unavailable"),
+            Error::MessageDkimSigned => write!(f, "Message is already signed"),
         }
     }
 }


### PR DESCRIPTION
- New `send_msg(&mut self, message: &Message<'x>)` to send message which was already transformed using `IntoMessage`. Now you can have owned `Message`, so if any error occurs, you don't loose the entire message, so you can send it again.
- New `sign(&mut self, signer: &DkimSigner<_>)` method on `Message`, which signs message in place, and then message can be sent using usual `send()`.
- Couple `#[inline]`, because compiler does not inline by default, as far as I know, so you need to tell it which function you think may be inlined. It improves performance.
- Sized traits