### PR TITLE
Remove skip-ehlo feature, replace with config option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ env_logger = "0.10.0"
 
 [features]
 default = ["digest-md5", "cram-md5", "builder", "dkim"]
-skip-ehlo = []
 builder = ["mail-builder"]
 dkim = ["mail-auth"]
 digest-md5 = ["md5", "rand"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,7 @@ pub struct SmtpClientBuilder<T: AsRef<str> + PartialEq + Eq + Hash> {
     pub addr: String,
     pub is_lmtp: bool,
     pub local_host: String,
+    pub skip_ehlo: bool,
 }
 
 /// SMTP client builder

--- a/src/smtp/builder.rs
+++ b/src/smtp/builder.rs
@@ -35,6 +35,7 @@ impl<T: AsRef<str> + PartialEq + Eq + Hash> SmtpClientBuilder<T> {
                 .unwrap_or("[127.0.0.1]")
                 .to_string(),
             credentials: None,
+            skip_ehlo: false,
         }
     }
 
@@ -74,6 +75,11 @@ impl<T: AsRef<str> + PartialEq + Eq + Hash> SmtpClientBuilder<T> {
         self
     }
 
+    pub fn skip_ehlo(mut self, skip_ehlo: bool) -> Self {
+        self.skip_ehlo = skip_ehlo;
+        self
+    }
+
     /// Connect over TLS
     #[allow(unused_mut)]
     pub async fn connect(&self) -> crate::Result<SmtpClient<TlsStream<TcpStream>>> {
@@ -109,8 +115,7 @@ impl<T: AsRef<str> + PartialEq + Eq + Hash> SmtpClientBuilder<T> {
                 }
             };
 
-            #[cfg(not(feature = "skip-ehlo"))]
-            {
+            if !self.skip_ehlo {
                 // Obtain capabilities
                 let capabilities = client.capabilities(&self.local_host, self.is_lmtp).await?;
 
@@ -141,8 +146,7 @@ impl<T: AsRef<str> + PartialEq + Eq + Hash> SmtpClientBuilder<T> {
         // Read greeting
         client.read().await?.assert_positive_completion()?;
 
-        #[cfg(not(feature = "skip-ehlo"))]
-        {
+        if !self.skip_ehlo {
             // Obtain capabilities
             let capabilities = client.capabilities(&self.local_host, self.is_lmtp).await?;
 


### PR DESCRIPTION
Hi, I love the work on Stalwart mail server!

Depending on the mail-send crate across a larger codebase sometimes requires skipping EHLO and sometimes doesn't. Using compile-time flags results in accidental behaviour where all usage either skips or doesn't skip, or care is needed to compile and use two separate dependencies, with some other headaches potentially requiring multiple mail-builder deps.

This PR removes the `skip-ehlo` compile-time feature in favour of a config option in the `SmtpClientBuilder` for usability. If you're happy to include this PR, I can make a matching PR to fix usages in mail-server and any other stalwart repos that use the `skip-ehlo` feature.

Let me know if there's anything else I can do to make this an easy change.

Matching PR: https://github.com/stalwartlabs/mail-server/pull/121

Cheers,
Liam