### PR TITLE
Windowing escape for CRLF.CRLF

### DIFF
--- a/src/smtp/client.rs
+++ b/src/smtp/client.rs
@@ -234,14 +234,37 @@ mod test {
     #[tokio::test]
     async fn transparency_procedure() {
         for (test, result) in [
+            // escapes required
             (
                 "A: b\r\n.\r\n".to_string(),
                 "A: b\r\n..\r\n\r\n.\r\n".to_string(),
             ),
+            (
+                "A: b\r.\r\n".to_string(),
+                "A: b\r..\r\n\r\n.\r\n".to_string(),
+            ),
+            (
+                "A: b\n.\r\n".to_string(),
+                "A: b\n..\r\n\r\n.\r\n".to_string(),
+            ),
+            (
+                "A: b\r\n.\r\nSome text".to_string(),
+                "A: b\r\n..\r\nSome text\r\n.\r\n".to_string(),
+            ),
+            (
+                "A: b\r.\r\nSome text".to_string(),
+                "A: b\r..\r\nSome text\r\n.\r\n".to_string(),
+            ),
+            (
+                "A: b\n.\r\nSome text".to_string(),
+                "A: b\n..\r\nSome text\r\n.\r\n".to_string(),
+            ),
             ("A: b\r\n.".to_string(), "A: b\r\n..\r\n.\r\n".to_string()),
+
+            // no escapes required
             (
                 "A: b\r\n..\r\n".to_string(),
-                "A: b\r\n...\r\n\r\n.\r\n".to_string(),
+                "A: b\r\n..\r\n\r\n.\r\n".to_string(),
             ),
             ("A: ...b".to_string(), "A: ...b\r\n.\r\n".to_string()),
         ] {

--- a/src/smtp/message.rs
+++ b/src/smtp/message.rs
@@ -133,7 +133,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> SmtpClient<T> {
         }
 
         // trailing \n. or \r. patterns also should be escaped
-        if let Some(bytes) = message.get(message.len() - 2..) {
+        if let Some(bytes) = message.get(message.len().saturating_sub(2)..) {
             if bytes.len() == 2 && bytes[1] == b'.' && (bytes[0] == b'\n' || bytes[0] == b'\r') {
                 self.stream.write_all(b".").await?;
             }


### PR DESCRIPTION
This escaping intends to:

1. Avoid `\n.example_function()` becoming `\n..example_function()`
2. Escape `\r.\n` and `\r.\r`.