### PR TITLE
Add `NOOP` command

### DIFF
--- a/src/smtp/envelope.rs
+++ b/src/smtp/envelope.rs
@@ -63,6 +63,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin> SmtpClient<T> {
         self.cmd(b"RSET\r\n").await?.assert_positive_completion()
     }
 
+    /// Sends a NOOP command to the server.
+    pub async fn noop(&mut self) -> crate::Result<()> {
+        self.cmd(b"NOOP\r\n").await?.assert_positive_completion()
+    }
+
     /// Sends a QUIT command to the server.
     pub async fn quit(mut self) -> crate::Result<()> {
         self.cmd(b"QUIT\r\n").await?.assert_positive_completion()


### PR DESCRIPTION
This PR adds the `NOOP` command as defined in the [RFC 5321, section 4.1.1.9](https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.1.9).