### PR TITLE
Derive Clone for mail_send::smtp::message::{Message, Address, Parameters, Parameter}.

### DIFF
--- a/src/smtp/message.rs
+++ b/src/smtp/message.rs
@@ -24,25 +24,25 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
 use crate::SmtpClient;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Message<'x> {
     pub mail_from: Address<'x>,
     pub rcpt_to: Vec<Address<'x>>,
     pub body: Cow<'x, [u8]>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Address<'x> {
     pub email: Cow<'x, str>,
     pub parameters: Parameters<'x>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Parameters<'x> {
     params: Vec<Parameter<'x>>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Parameter<'x> {
     key: Cow<'x, str>,
     value: Option<Cow<'x, str>>,


### PR DESCRIPTION
At the moment `SmtpClient::send` takes `impl IntoMessage` as an argument, thus it takes ownership of a message and in times when message sending fails and it is necessary to retry sending the same message a bit later, it is not possible to do so, because it has been moved.

This is why we #[derive(Clone)] for Message, Address, Parameters, Parameter.

Now it is possible to clone message before sending it. On success we can drop the original, on retry cases we can clone original again, update some parameters and resend.