### PR TITLE
Add the option to choose the sending IP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@
 //!
 
 pub mod smtp;
+use std::net::IpAddr;
 use std::{fmt::Display, hash::Hash, time::Duration};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_rustls::TlsConnector;
@@ -205,6 +206,7 @@ pub struct SmtpClientBuilder<T: AsRef<str> + PartialEq + Eq + Hash> {
     pub is_lmtp: bool,
     pub say_ehlo: bool,
     pub local_host: String,
+    pub local_ip: Option<IpAddr>,
 }
 
 /// SMTP client builder


### PR DESCRIPTION
With this PR, I would like to introduce the possibility to explicitly choose which local IP should be used for sending out email. This is useful if your machine has multiple public IPs assigned, and you want to ensure that you are using the intended one. Using an IP with good repudiation is quite important when you want to ensure deliverability.

Note that the configuration option is completely optional, and the changes are backward compatible.

Please let me know if you have any further questions or would like me to optimize the code in some way.