### PR TITLE
Update mail-auth to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 [dependencies]
 smtp-proto = { version = "0.2" }
-mail-auth = { version = "0.8", optional = true }
+mail-auth = { version = "0.10", optional = true }
 mail-builder = { version = "0.4", optional = true }
 mail-parser = { version = "0.11", optional = true }
 base64 = "0.22"


### PR DESCRIPTION
This is to fix cargo audit report about this vulnerability.

hickory-proto 0.26.0-alpha.1
└── hickory-resolver 0.26.0-alpha.1
    └── mail-auth 0.8.0
        └── mail-send 0.6.0
            └── smtp-xoauth2-test-tool 1.4.0

Crate:     hickory-proto
Version:   0.26.0-alpha.1
Title:     CPU exhaustion during message encoding due to O(n²) name compression
Date:      2026-05-01
ID:        RUSTSEC-2026-0119
URL:       https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp
Solution:  Upgrade to >=0.26.1